### PR TITLE
chore: move wiki data directory

### DIFF
--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -49,5 +49,5 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           platforms: linux/amd64,linux/arm64,linux/amd64/v2,linux/arm/v7
           build-args: |
-            BUILD_DATE=${{ steps.date.outputs.date }}
+            BUILD_DATE=${{ steps.prep.outputs.date }}
             VCS_REF=${{ github.sha }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,7 @@ ENV DEBIAN_FRONTEND=noninteractive  \
     UNAME=student
 
 WORKDIR /course
-VOLUME [ "/course", "/wiki_data" ]
+VOLUME [ "/course" ]
 ENTRYPOINT [ "/scripts/entrypoint.sh" ]
 
 EXPOSE 3000
@@ -35,7 +35,6 @@ RUN useradd -m -s /bin/bash -u "${UID}" "${UNAME}" && \
     echo "${UNAME}:password" | chpasswd
 
 RUN mkdir -p \
-        /wiki_data \
         /builtin/jupyter \
         /builtin/coursework \
         /opt/static/lectures  \
@@ -102,7 +101,7 @@ COPY configs/jupyter_lab_config.py /opt/jupyter/jupyter_lab_config.py
 
 # copy all the builtin jupyter notebooks
 COPY builtinNotebooks /builtin/jupyter
-RUN chown -R ${UID}:${UID} /builtin /opt/static /course /opt/wiki /wiki_data
+RUN chown -R ${UID}:${UID} /builtin /opt/static /course /opt/wiki
 
 COPY scripts /scripts/
 COPY motd.txt /scripts/

--- a/configs/wiki_config.yml
+++ b/configs/wiki_config.yml
@@ -129,4 +129,4 @@ ha: false
 # Data Path
 # ---------------------------------------------------------------------
 # Writeable data path used for cache and temporary user uploads.
-dataPath: /wiki_data
+dataPath: /course/wiki/data

--- a/scripts/001-filesetup.sh
+++ b/scripts/001-filesetup.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # copy the wiki database if it is not already there
-cp /opt/wiki/database.sqlite /course/wiki/database.sqlite
+cp -n -v /opt/wiki/database.sqlite /course/wiki/database.sqlite
 
 # Copy the builtin content to the mounted volume
 cp -n -r -u -v /builtin/jupyter/. /course/jupyter/notebooks/tutorials/

--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -29,7 +29,7 @@ fi
 
 # Setup directories in the potentially mounted volume
 LOGDIR="/course/logs"
-mkdir -p "/course/wiki" \
+mkdir -p "/course/wiki/data" \
         "/course/jupyter/notebooks/tutorials"  \
         "/course/coursework" \
         "/course/lectures" \


### PR DESCRIPTION

Close: #8

- fix: build date had the wrong step input name
- chore: move the wiki data directory into the course volume mount
